### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,9 @@ import pandas as pd
 df = pd.read_csv("https://raw.githubusercontent.com/globaldothealth/monkeypox/main/latest.csv")
 ```
 
-**R** (requires `httr`):
+**R** :
 ```r
-library(httr)
-df <- read.csv(text=content(GET("https://raw.githubusercontent.com/globaldothealth/monkeypox/main/latest.csv")))
+df <- read.csv("https://raw.githubusercontent.com/globaldothealth/monkeypox/main/latest.csv")
 ```
 
 ## Contributing


### PR DESCRIPTION
This feels like a silly PR, but `httr` isn't necessary to read in a CSV from a web link. `read.csv` from base supports reads from URL natively.