### PR TITLE
timeseries fill use uk

### DIFF
--- a/src/test_timeseries.py
+++ b/src/test_timeseries.py
@@ -40,60 +40,6 @@ BY_CONFIRMED = [
 
 BY_COUNTRY_CONFIRMED = [
     {
-        "Date": Timestamp("2022-06-01 00:00:00"),
-        "Cases": 1,
-        "Cumulative_cases": 1,
-        "Country": "England",
-    },
-    {
-        "Date": Timestamp("2022-06-02 00:00:00"),
-        "Cases": 0,
-        "Cumulative_cases": 1,
-        "Country": "England",
-    },
-    {
-        "Date": Timestamp("2022-06-03 00:00:00"),
-        "Cases": 3,
-        "Cumulative_cases": 4,
-        "Country": "England",
-    },
-    {
-        "Date": Timestamp("2022-06-04 00:00:00"),
-        "Cases": 0,
-        "Cumulative_cases": 4,
-        "Country": "England",
-    },
-     {
-        "Date": Timestamp("2022-06-05 00:00:00"),
-        "Cases": 0,
-        "Cumulative_cases": 4,
-        "Country": "England",
-    },
-     {
-        "Date": Timestamp("2022-06-06 00:00:00"),
-        "Cases": 0,
-        "Cumulative_cases": 4,
-        "Country": "England",
-    },
-     {
-        "Date": Timestamp("2022-06-07 00:00:00"),
-        "Cases": 0,
-        "Cumulative_cases": 4,
-        "Country": "England",
-    },
-     {
-        "Date": Timestamp("2022-06-08 00:00:00"),
-        "Cases": 0,
-        "Cumulative_cases": 4,
-        "Country": "England",
-    },
-     {
-        "Date": Timestamp("2022-06-09 00:00:00"),
-        "Cases": 0,
-        "Cumulative_cases": 4,
-        "Country": "England",
-    },
-    {
         "Date": Timestamp("2022-06-02 00:00:00"),
         "Cases": 1,
         "Cumulative_cases": 1,
@@ -141,7 +87,60 @@ BY_COUNTRY_CONFIRMED = [
         "Cumulative_cases": 5,
         "Country": "USA",
     },
-
+    {
+        "Date": Timestamp("2022-06-01 00:00:00"),
+        "Cases": 1,
+        "Cumulative_cases": 1,
+        "Country": "United Kingdom",
+    },
+    {
+        "Date": Timestamp("2022-06-02 00:00:00"),
+        "Cases": 0,
+        "Cumulative_cases": 1,
+        "Country": "United Kingdom",
+    },
+    {
+        "Date": Timestamp("2022-06-03 00:00:00"),
+        "Cases": 3,
+        "Cumulative_cases": 4,
+        "Country": "United Kingdom",
+    },
+    {
+        "Date": Timestamp("2022-06-04 00:00:00"),
+        "Cases": 0,
+        "Cumulative_cases": 4,
+        "Country": "United Kingdom",
+    },
+    {
+        "Date": Timestamp("2022-06-05 00:00:00"),
+        "Cases": 0,
+        "Cumulative_cases": 4,
+        "Country": "United Kingdom",
+    },
+    {
+        "Date": Timestamp("2022-06-06 00:00:00"),
+        "Cases": 0,
+        "Cumulative_cases": 4,
+        "Country": "United Kingdom",
+    },
+    {
+        "Date": Timestamp("2022-06-07 00:00:00"),
+        "Cases": 0,
+        "Cumulative_cases": 4,
+        "Country": "United Kingdom",
+    },
+    {
+        "Date": Timestamp("2022-06-08 00:00:00"),
+        "Cases": 0,
+        "Cumulative_cases": 4,
+        "Country": "United Kingdom",
+    },
+    {
+        "Date": Timestamp("2022-06-09 00:00:00"),
+        "Cases": 0,
+        "Cumulative_cases": 4,
+        "Country": "United Kingdom",
+    },
 ]
 
 

--- a/src/test_timeseries.py
+++ b/src/test_timeseries.py
@@ -5,6 +5,8 @@ from pandas import Timestamp
 
 import timeseries
 
+TODAY = pd.Timestamp(2022, 6, 9)
+
 DATA = pd.read_csv(
     io.StringIO(
         """
@@ -30,6 +32,10 @@ BY_CONFIRMED = [
     {"Date": Timestamp("2022-06-03 00:00:00"), "Cases": 3, "Cumulative_cases": 5},
     {"Date": Timestamp("2022-06-04 00:00:00"), "Cases": 0, "Cumulative_cases": 5},
     {"Date": Timestamp("2022-06-05 00:00:00"), "Cases": 4, "Cumulative_cases": 9},
+    {"Date": Timestamp("2022-06-06 00:00:00"), "Cases": 0, "Cumulative_cases": 9},
+    {"Date": Timestamp("2022-06-07 00:00:00"), "Cases": 0, "Cumulative_cases": 9},
+    {"Date": Timestamp("2022-06-08 00:00:00"), "Cases": 0, "Cumulative_cases": 9},
+    {"Date": Timestamp("2022-06-09 00:00:00"), "Cases": 0, "Cumulative_cases": 9},
 ]
 
 BY_COUNTRY_CONFIRMED = [
@@ -48,6 +54,42 @@ BY_COUNTRY_CONFIRMED = [
     {
         "Date": Timestamp("2022-06-03 00:00:00"),
         "Cases": 3,
+        "Cumulative_cases": 4,
+        "Country": "England",
+    },
+    {
+        "Date": Timestamp("2022-06-04 00:00:00"),
+        "Cases": 0,
+        "Cumulative_cases": 4,
+        "Country": "England",
+    },
+     {
+        "Date": Timestamp("2022-06-05 00:00:00"),
+        "Cases": 0,
+        "Cumulative_cases": 4,
+        "Country": "England",
+    },
+     {
+        "Date": Timestamp("2022-06-06 00:00:00"),
+        "Cases": 0,
+        "Cumulative_cases": 4,
+        "Country": "England",
+    },
+     {
+        "Date": Timestamp("2022-06-07 00:00:00"),
+        "Cases": 0,
+        "Cumulative_cases": 4,
+        "Country": "England",
+    },
+     {
+        "Date": Timestamp("2022-06-08 00:00:00"),
+        "Cases": 0,
+        "Cumulative_cases": 4,
+        "Country": "England",
+    },
+     {
+        "Date": Timestamp("2022-06-09 00:00:00"),
+        "Cases": 0,
         "Cumulative_cases": 4,
         "Country": "England",
     },
@@ -75,14 +117,40 @@ BY_COUNTRY_CONFIRMED = [
         "Cumulative_cases": 5,
         "Country": "USA",
     },
+    {
+        "Date": Timestamp("2022-06-06 00:00:00"),
+        "Cases": 0,
+        "Cumulative_cases": 5,
+        "Country": "USA",
+    },
+    {
+        "Date": Timestamp("2022-06-07 00:00:00"),
+        "Cases": 0,
+        "Cumulative_cases": 5,
+        "Country": "USA",
+    },
+    {
+        "Date": Timestamp("2022-06-08 00:00:00"),
+        "Cases": 0,
+        "Cumulative_cases": 5,
+        "Country": "USA",
+    },
+    {
+        "Date": Timestamp("2022-06-09 00:00:00"),
+        "Cases": 0,
+        "Cumulative_cases": 5,
+        "Country": "USA",
+    },
+
 ]
 
 
 def test_by_confirmed():
-    assert timeseries.by_confirmed(DATA).to_dict("records") == BY_CONFIRMED
+    assert timeseries.by_confirmed(DATA, TODAY).to_dict("records") == BY_CONFIRMED
 
 
 def test_by_country_confirmed():
     assert (
-        timeseries.by_country_confirmed(DATA).to_dict("records") == BY_COUNTRY_CONFIRMED
+        timeseries.by_country_confirmed(DATA, TODAY).to_dict("records")
+        == BY_COUNTRY_CONFIRMED
     )

--- a/src/timeseries.py
+++ b/src/timeseries.py
@@ -7,6 +7,8 @@ Based on code by @tannervarrelman
 import io
 import pandas as pd
 
+today = pd.Timestamp.today()
+
 
 def to_json(df: pd.DataFrame) -> str:
     return df.to_json(orient="records", date_format="iso", indent=2)
@@ -18,30 +20,40 @@ def to_csv(df: pd.DataFrame) -> str:
     return buf.getvalue()
 
 
-def by_confirmed(df: pd.DataFrame) -> pd.DataFrame:
+def by_confirmed(df: pd.DataFrame, last_date: pd.Timestamp = None) -> pd.DataFrame:
     """Returns timeseries of counts and cumulative counts of cases"""
 
+    last_date = last_date or today
     confirmed = df[df.Status == "confirmed"]
     confirmed = confirmed.assign(Date=pd.to_datetime(confirmed.Date_confirmation))
     counts = confirmed.groupby("Date").size().resample("D").sum()
+    counts = counts.reindex(pd.date_range(counts.index.min(), last_date), fill_value=0)
     return (
         pd.DataFrame([counts, counts.cumsum()])
         .T.reset_index()
-        .rename(columns={0: "Cases", 1: "Cumulative_cases"})
+        .rename(columns={0: "Cases", 1: "Cumulative_cases", "index": "Date"})
     )
 
 
-def by_country_confirmed(df: pd.DataFrame) -> pd.DataFrame:
+def by_country_confirmed(
+    df: pd.DataFrame, last_date: pd.Timestamp = None
+) -> pd.DataFrame:
     """Returns timeseries of counts and cumulative counts of cases by country"""
+
+    last_date = last_date or today
     confirmed = df[df.Status == "confirmed"]
     confirmed = confirmed.assign(Date=pd.to_datetime(confirmed.Date_confirmation))
     dfs = []
     for country, country_df in confirmed.groupby("Country"):
         country_counts = country_df.groupby("Date").size().resample("D").sum()
+        country_counts = country_counts.reindex(
+            pd.date_range(country_counts.index.min(), last_date),
+            fill_value=0,
+        )
         dfs.append(
             pd.DataFrame([country_counts, country_counts.cumsum()])
             .T.reset_index()
-            .rename(columns={0: "Cases", 1: "Cumulative_cases"})
+            .rename(columns={0: "Cases", 1: "Cumulative_cases", "index": "Date"})
             .assign(Country=country)
         )
     return pd.concat(dfs).reset_index().drop("index", axis=1)

--- a/src/timeseries.py
+++ b/src/timeseries.py
@@ -9,6 +9,7 @@ import pandas as pd
 
 today = pd.Timestamp.today()
 
+UK_COUNTRIES = ["England", "Wales", "Scotland", "Northern Ireland"]
 
 def to_json(df: pd.DataFrame) -> str:
     return df.to_json(orient="records", date_format="iso", indent=2)
@@ -42,7 +43,10 @@ def by_country_confirmed(
 
     last_date = last_date or today
     confirmed = df[df.Status == "confirmed"]
-    confirmed = confirmed.assign(Date=pd.to_datetime(confirmed.Date_confirmation))
+    confirmed = confirmed.assign(
+        Date=pd.to_datetime(confirmed.Date_confirmation),
+        Country=confirmed.Country.replace(UK_COUNTRIES, "United Kingdom"),
+    )
     dfs = []
     for country, country_df in confirmed.groupby("Country"):
         country_counts = country_df.groupby("Date").size().resample("D").sum()


### PR DESCRIPTION
- timeseries: fill series upto today with zeros
- timeseries: replace UK constituent countries with UK
