### PR TITLE
app: use csv.DictWriter instead of csv.writer

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -110,14 +110,14 @@ def clean_data(data: Data, id_prefix: str = "") -> Data:
     return data
 
 
-def format_data(data: Data) -> tuple[str, str]:
+def format_data(data: Data, fields: Optional[list[str]] = FIELDS) -> tuple[str, str]:
     logging.info("Formatting data")
     json_data = json.dumps(data)
     csv_data = io.StringIO()
-    csv_writer = csv.writer(csv_data)
-    csv_writer.writerow(data[0].keys())  # column names
+    csv_writer = csv.DictWriter(csv_data, fieldnames=fields)
+    csv_writer.writeheader()
     for row in data:
-        csv_writer.writerow(row.values())
+        csv_writer.writerow(row)
     return json_data, csv_data.getvalue()
 
 

--- a/src/test_app.py
+++ b/src/test_app.py
@@ -110,7 +110,10 @@ N2,2022-05-05,USA,USA,suspected
 N3,2022-01-01,Spain,ESP,discarded
 N4,2022-03-03,Australia,AUS,omit_error
 """
-    actual_JSON, actual_CSV = app.format_data(CLEANED_OUTPUT)
+    actual_JSON, actual_CSV = app.format_data(
+        CLEANED_OUTPUT,
+        fields=["ID", "Date_confirmation", "Country", "Country_ISO3", "Status"]
+    )
     assert actual_JSON == expected_JSON
     assert actual_CSV.splitlines() == expected_CSV.splitlines()
 


### PR DESCRIPTION
csv.DictWriter allows specification of field names, and can
substitute empty values where the field value is missing. This
is useful in merging the endemic and non-endemic lists as the
endemic list has many missing fields and the order of the fields
does not necessarily match that of the non-endemic list.
